### PR TITLE
Clean up readme a bit.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ class Application extends BaseApplication
 }
 ```
 
-If one of the configured authenticators was able to validate the credentials the middeleware will add the authentication service to the request object as attribute.
+If one of the configured authenticators was able to validate the credentials, the middeleware will add the authentication service to the request object as attribute.
 
 If you're not yet familiar with request attributes [check the PSR7 documentation](http://www.php-fig.org/psr/psr-7/).
 
@@ -57,28 +57,28 @@ $user = $authentication->getIdentity();
 
 ### Differences
 
-* There is no automatic checking of the session. To get the actual user data from the session you'll have to use the `Auth.Session` authenticator. It will check the session if there is data in the configured session key and put it into the identity object.
-* The user data is no longer available  through the auth component but accessible via a request attribute and encapsulated in an identity object: `$request->getAttribute('authentication')->getIdentity();`
-* The logic of the authentication process has been split into authenticators and identifiers. An authenticator will extract the credentials and check them against a set of identifiers to actually verify and identify the request.
+* There is no automatic checking of the session. To get the actual user data from the session you'll have to use the `SessionAuthenticator`. It will check the session if there is data in the configured session key and put it into the identity object.
+* The user data is no longer available through the AuthComponent but is accessible via a request attribute and encapsulated in an identity object: `$request->getAttribute('authentication')->getIdentity();`
+* The logic of the authentication process has been split into authenticators and identifiers. An authenticator will extract the credentials from the request, while identifiers verify the credentials and find the matching user.
 
 ### Similarities
 
-* All the existing authentication adapters, Form, Basic, Digest are still there but have been refactored into so called authenticators.
+* All the existing authentication adapters, Form, Basic, Digest are still there but have been refactored into authenticators.
 
 ### Identifiers and authenticators
 
-Following the principle of separation of concerns the former monolithic authentication objects were split into two separate objects, identifiers and authenticators.
- 
-* **Authenticators** take the incoming request and try to get identification credentials from it which they then pass to a collection of identifiers. Fort that reason authenticators take an IdentifierCollection as first constructor argument.
-* **Identifiers** are objects that try to verify identification credentials against a system and return identity data. 
+Following the principle of separation of concerns, the former authentication objects were split into separate objects, identifiers and authenticators.
 
-This makes it easy to change the identification logic as needed or add several methods of identifying credentials.
+* **Authenticators** take the incoming request and try to extract identification credentials from it. If credentials are found, they are passed to a collection of identifiers where the user is located. For that reason authenticators take an IdentifierCollection as first constructor argument.
+* **Identifiers** are verify identification credentials against a storage system. eg. (ORM tables, LDAP etc) and return identified user data.
 
-If you want to implement your own identifiers, your identifier must implement the IdentifierInterface.
+This makes it easy to change the identification logic as needed or use several sources of user data.
+
+If you want to implement your own identifiers, your identifier must implement the `IdentifierInterface`.
 
 ### Migrating your authentication setup
 
-Remove authentication from the Auth component and put the middleware in place like shown above and configure your authenticators the same way as you did for the Auth component before.
+Remove authentication from the AuthComponent and put the middleware in place like shown above. Then configure your authenticators the same way as you did for the AuthComponent before.
 
 Change your code to use the identity object instead of using `$this->Auth->user()`;
 


### PR DESCRIPTION
Clean up the readme a bit.

I also wonder if we should be attaching the entire `AuthenticationService` to the request when instead we could just attach the `IdentiferInstance`. This makes our 'public' API smaller and I don't really understand the scenarios in which a user would want the service, when they could have the user/result instead.